### PR TITLE
Fix cjs module export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
           - 20.x
           - 22.x
+          - 24.x
 
     steps:
       - uses: actions/checkout@v6
@@ -49,10 +49,10 @@ jobs:
       - run: npm run build:wasm
 
       # Catch Node import failures that don't reproduce in Jest <https://github.com/foxglove/wasm-bz2/issues/4>
-      - run: node -e 'require("./dist/index.js").default.init()'
+      - run: node -e 'require("./dist/index.js").init()'
 
       - run: npm run test
 
       - name: Publish to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.node-version == '22.x' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.node-version == '24.x' }}
         run: npx npm@11.7.0 publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/wasm-bz2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Bzip2 decompression compiled to WebAssembly",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import ModuleFactory, { BZ2Module } from "../wasm/module";
 
-export default class Bzip2 {
+class Bzip2 {
   static async init(): Promise<Bzip2> {
     return new Bzip2(await ModuleFactory());
   }
@@ -35,3 +35,5 @@ export default class Bzip2 {
     }
   }
 }
+
+export = Bzip2;


### PR DESCRIPTION
Update export from `exports.default = Bzip2` to `module.exports = Bzip2` to align with cjs conventions.

The former was causing issues with cjs/esm interop, requiring import as `Bzip2.default.default` which is silly.